### PR TITLE
ci: implement initial CI for linting and running molecule tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
     strategy:
       matrix:
         distro:
-          - rockylinux8
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
           - debian10
           - debian11
-          - fedora34
+          - fedora36
+          - fedora38
 
     steps:
       - name: Check out the codebase.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+---
+name: CI
+"on":
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 7 * * 0"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install lint dependencies.
+        run: pip3 install yamllint
+
+      - name: Lint code.
+        run: |
+          yamllint .
+
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro:
+          - rockylinux8
+          - ubuntu1804
+          - ubuntu2004
+          - ubuntu2204
+          - debian10
+          - debian11
+          - fedora34
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install test dependencies.
+        run: pip3 install ansible ansible-lint molecule-plugins[docker] docker
+
+      - name: Run Molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/kmezynski/ansible-role-neovim/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/kmezynski/ansible-role-neovim/actions/workflows/ci.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/kmezynski/ansible-role-neovim/master.svg)](https://results.pre-commit.ci/latest/github/kmezynski/ansible-role-neovim/master)
 
 # Ansible Role: Neovim

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,7 +22,10 @@ galaxy_info:
         - jammy
     - name: Fedora
       versions:
-        - all
+        - 36
+        - 37
+        - 38
+        - 39
 
   galaxy_tags:
     - neovim

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,11 +29,6 @@
     version: master
     single_branch: true
 
-- name: Install linter for Lua.
-  ansible.builtin.command: luarocks install luacheck
-  args:
-    creates: /usr/local/bin/luacheck
-
 - name: Ensure directory for Packer config exists.
   ansible.builtin.file:
     path: "{{ neovim_packer_config_path }}"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,3 +6,8 @@
     name: "{{ neovim_packages }}"
     state: present
     install_recommends: false
+
+- name: Install linter for Lua.
+  ansible.builtin.command: luarocks install luacheck
+  args:
+    creates: /usr/local/bin/luacheck

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -2,5 +2,6 @@
 - name: Ensure Neovim build dependencies are installed.
   become: true
   ansible.builtin.yum:
+    update_cache: true
     name: "{{ neovim_packages }}"
     state: present

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -5,3 +5,8 @@
     update_cache: true
     name: "{{ neovim_packages }}"
     state: present
+
+- name: Install linter for Lua.
+  ansible.builtin.command: luarocks install luacheck
+  args:
+    creates: /usr/bin/luacheck

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,5 +6,4 @@ neovim_packages:
   - unzip
   - gettext
   - curl
-  - lua
   - luarocks

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,4 +6,5 @@ neovim_packages:
   - unzip
   - gettext
   - curl
+  - lua
   - luarocks

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,4 +8,6 @@ neovim_packages:
   - unzip
   - gettext
   - curl
+  - lua
+  - lua-devel
   - luarocks

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,6 +8,5 @@ neovim_packages:
   - unzip
   - gettext
   - curl
-  - lua
   - lua-devel
   - luarocks


### PR DESCRIPTION
- ci: implement initial CI for linting and running molecule tests
- docs: add status badge for CI workflow
- deps(role): add dependencies for Lua installation
- ci: drop support for all Rocky Linux and Fedora <35 images
Relates to https://github.com/lunarmodules/luacheck#99
- refactor: fix idempotence for RedHat distributions